### PR TITLE
Include Apache zookeeper patch to handle htonll conflict when compiled on Mac OSX Yosemite. Added minor details to README.md for clarity.

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ There are however, a few dependencies which we cannot easily satisfy:
 Install XCode 6 with the command line tools. Then:
     brew install automake
     brew install autoconf
+    brew install cmake
 
 ### Satisfying Dependencies on Ubuntu
 
@@ -105,11 +106,11 @@ Compiling
 Running configure will create two sub-directories, *release* and *debug*.  Select 
 either of these modes/directories and navigate to the *src/unity* subdirectory:
 
-    cd debug/src/unity
+    cd <repo root>/debug/src/unity
    
    or
    
-    cd release/src/unity
+    cd <repo root>/release/src/unity
 
 Running **make** will build the project, according to the mode selected. 
 
@@ -123,19 +124,25 @@ GraphLab Create does require a large amount of memory to compile with the
 heaviest toolkit requiring 1GB of RAM. Where **K** is the amount of memory you
 have on your machine in GB, we recommend not exceeding **make -j K**
 
-To generate the python, navigate to the *python* subdirectory:
+To generate the python code bindings,
 
-    cd python
+Navigate to the *python* subdirectories and run **make** to generate Python code bindings. Remember to replace <*repo root*> with the absolute path to the root of your repository.
 
-and run **make** again.
 
+    cd <repo root>/debug/src/unity/python
     make
+    
+    or
+
+    cd <repo root>/release/src/unity/python
+    make
+
 
 To use your dev build export these environment variables:
   
     export GRAPHLAB_UNITY="<repo root>/debug/src/unity/server/unity_server"
  
- where <*repo root*> is replaced with the absolute path to the root of your repository. Then run pip install to pull in dependencies and set the python path.
+Then run pip install to pull in dependencies and set the python path.
 
     # recommended -- use a virtual environment
     virtualenv venv
@@ -152,14 +159,14 @@ Running Unit Tests
 ### Running Python unit tests
 From the repo root:
 
-    cd debug/src/unity/python/graphlab/test
+    cd <repo root>/debug/src/unity/python/graphlab/test
     nosetests
 
 
 ### Running C++ units
 From the repo root:
 
-    cd debug/test
+    cd <repo root>/debug/test
     make
     ctest
 

--- a/cmake/ExternalProjectZookeeper.cmake
+++ b/cmake/ExternalProjectZookeeper.cmake
@@ -2,12 +2,11 @@ ExternalProject_Add(zookeeper
   PREFIX ${CMAKE_SOURCE_DIR}/deps/zookeeper
   URL http://s3-us-west-2.amazonaws.com/glbin-engine/deps/zookeeper-3.4.6.tar.gz
   URL_MD5 971c379ba65714fd25dc5fe8f14e9ad1
+  PATCH_COMMAND patch -N -p0 -i ${CMAKE_SOURCE_DIR}/patches/zookeeper.patch || true
   PATCH_COMMAND ${CMAKE_COMMAND} -E copy_directory ${CMAKE_SOURCE_DIR}/patches/zookeeper/ <SOURCE_DIR>
   BUILD_IN_SOURCE 1
   CONFIGURE_COMMAND CFLAGS=-fPIC CPPFLAGS=-fPIC CC=${CMAKE_C_COMPILER} CXX=${CMAKE_CXX_COMPILER} ./configure --prefix=<INSTALL_DIR> --disable-shared
   INSTALL_DIR ${CMAKE_SOURCE_DIR}/deps/local)
-
-
 
  macro(requires_zookeeper NAME)
   add_dependencies(${NAME} zookeeper)

--- a/patches/zookeeper.patch
+++ b/patches/zookeeper.patch
@@ -1,0 +1,106 @@
+diff --git src/c/include/recordio.h src/c/include/recordio.h
+index 4e1b78e..90f458b 100644
+--- src/c/include/recordio.h
++++ src/c/include/recordio.h
+@@ -73,7 +73,7 @@ void close_buffer_iarchive(struct iarchive **ia);
+ char *get_buffer(struct oarchive *);
+ int get_buffer_len(struct oarchive *);
+ 
+-int64_t htonll(int64_t v);
++int64_t zoo_htonll(int64_t v);
+ 
+ #ifdef __cplusplus
+ }
+diff --git src/c/src/recordio.c src/c/src/recordio.c
+index cf8a1ac..41797fb 100644
+--- src/c/src/recordio.c
++++ src/c/src/recordio.c
+@@ -80,7 +80,7 @@ int oa_serialize_int(struct oarchive *oa, const char *tag, const int32_t *d)
+     priv->off+=sizeof(i);
+     return 0;
+ }
+-int64_t htonll(int64_t v)
++int64_t zoo_htonll(int64_t v)
+ {
+     int i = 0;
+     char *s = (char *)&v;
+@@ -98,7 +98,7 @@ int64_t htonll(int64_t v)
+ 
+ int oa_serialize_long(struct oarchive *oa, const char *tag, const int64_t *d)
+ {
+-    const int64_t i = htonll(*d);
++    const int64_t i = zoo_htonll(*d);
+     struct buff_struct *priv = oa->priv;
+     if ((priv->len - priv->off) < sizeof(i)) {
+         int rc = resize_buffer(priv, priv->len + sizeof(i));
+@@ -207,7 +207,7 @@ int ia_deserialize_long(struct iarchive *ia, const char *tag, int64_t *count)
+     }
+     memcpy(count, priv->buffer+priv->off, sizeof(*count));
+     priv->off+=sizeof(*count);
+-    v = htonll(*count); // htonll and  ntohll do the same
++    v = zoo_htonll(*count); // htonll and  ntohll do the same
+     *count = v;
+     return 0;
+ }
+diff --git src/c/src/zookeeper.c src/c/src/zookeeper.c
+index 27ecf8a..ba55d27 100644
+--- src/c/src/zookeeper.c
++++ src/c/src/zookeeper.c
+@@ -1408,7 +1408,7 @@ static int serialize_prime_connect(struct connect_req *req, char* buffer){
+     memcpy(buffer + offset, &req->protocolVersion, sizeof(req->protocolVersion));
+     offset = offset +  sizeof(req->protocolVersion);
+ 
+-    req->lastZxidSeen = htonll(req->lastZxidSeen);
++    req->lastZxidSeen = zoo_htonll(req->lastZxidSeen);
+     memcpy(buffer + offset, &req->lastZxidSeen, sizeof(req->lastZxidSeen));
+     offset = offset +  sizeof(req->lastZxidSeen);
+ 
+@@ -1416,7 +1416,7 @@ static int serialize_prime_connect(struct connect_req *req, char* buffer){
+     memcpy(buffer + offset, &req->timeOut, sizeof(req->timeOut));
+     offset = offset +  sizeof(req->timeOut);
+ 
+-    req->sessionId = htonll(req->sessionId);
++    req->sessionId = zoo_htonll(req->sessionId);
+     memcpy(buffer + offset, &req->sessionId, sizeof(req->sessionId));
+     offset = offset +  sizeof(req->sessionId);
+ 
+@@ -1447,7 +1447,7 @@ static int serialize_prime_connect(struct connect_req *req, char* buffer){
+      memcpy(&req->sessionId, buffer + offset, sizeof(req->sessionId));
+      offset = offset +  sizeof(req->sessionId);
+ 
+-     req->sessionId = htonll(req->sessionId);
++     req->sessionId = zoo_htonll(req->sessionId);
+      memcpy(&req->passwd_len, buffer + offset, sizeof(req->passwd_len));
+      offset = offset +  sizeof(req->passwd_len);
+ 
+diff --git src/c/tests/ZKMocks.cc src/c/tests/ZKMocks.cc
+index 8916674..69bea16 100644
+--- src/c/tests/ZKMocks.cc
++++ src/c/tests/ZKMocks.cc
+@@ -41,7 +41,7 @@ HandshakeRequest* HandshakeRequest::parse(const std::string& buf){
+     int offset=sizeof(req->protocolVersion);
+     
+     memcpy(&req->lastZxidSeen,buf.data()+offset,sizeof(req->lastZxidSeen));
+-    req->lastZxidSeen = htonll(req->lastZxidSeen);
++    req->lastZxidSeen = zoo_htonll(req->lastZxidSeen);
+     offset+=sizeof(req->lastZxidSeen);
+     
+     memcpy(&req->timeOut,buf.data()+offset,sizeof(req->timeOut));
+@@ -49,7 +49,7 @@ HandshakeRequest* HandshakeRequest::parse(const std::string& buf){
+     offset+=sizeof(req->timeOut);
+     
+     memcpy(&req->sessionId,buf.data()+offset,sizeof(req->sessionId));
+-    req->sessionId = htonll(req->sessionId);
++    req->sessionId = zoo_htonll(req->sessionId);
+     offset+=sizeof(req->sessionId);
+     
+     memcpy(&req->passwd_len,buf.data()+offset,sizeof(req->passwd_len));
+@@ -322,7 +322,7 @@ string HandshakeResponse::toString() const {
+     buf.append((char*)&tmp,sizeof(tmp));
+     tmp=htonl(timeOut);
+     buf.append((char*)&tmp,sizeof(tmp));
+-    int64_t tmp64=htonll(sessionId);
++    int64_t tmp64=zoo_htonll(sessionId);
+     buf.append((char*)&tmp64,sizeof(sessionId));
+     tmp=htonl(passwd_len);
+     buf.append((char*)&tmp,sizeof(tmp));


### PR DESCRIPTION
See Apache Zookeeper JIRA ZOOKEEPER-2049
https://issues.apache.org/jira/browse/ZOOKEEPER-2049

The attached zookeeper.patch file applies to Apache Zookeeper version 3.4

Thanks!

![image](https://cloud.githubusercontent.com/assets/1020661/7665249/fa7a381c-fb63-11e4-8f4a-19048a7c55c1.png)
